### PR TITLE
Update entities-service version and use output in CI/CD

### DIFF
--- a/.github/workflows/cd_upload_entities.yml
+++ b/.github/workflows/cd_upload_entities.yml
@@ -32,6 +32,7 @@ jobs:
         run: entities-service --version
 
       - name: Gather Entities
+        id: gather_entities
         run: |
           if [ "${{ github.event_name }}" == "push" ]; then
             SHA_BEFORE="${{ github.event.before }}"
@@ -42,23 +43,23 @@ jobs:
           git diff --name-only ${SHA_BEFORE} | grep -E '^entities/.*\.json$' > entities.txt ||:
 
           if [ -s entities.txt ]; then
-            echo "RELEVANT_ENTITIES=true" >> $GITHUB_ENV
+            echo "RELEVANT_ENTITIES=true" >> $GITHUB_OUTPUT
 
             echo "Relevant Entities:"
             cat entities.txt
           else
-            echo "RELEVANT_ENTITIES=false" >> $GITHUB_ENV
+            echo "RELEVANT_ENTITIES=false" >> $GITHUB_OUTPUT
 
             echo "No entities to validate (and upload)."
             exit 0
           fi
 
       - name: Validate Entities
-        if: env.RELEVANT_ENTITIES == 'true'
+        if: steps.gather_entities.outputs.RELEVANT_ENTITIES == 'true'
         run: cat entities.txt | entities-service validate --strict --format=json -
 
       - name: Upload Entities
-        if: env.RELEVANT_ENTITIES == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: steps.gather_entities.outputs.RELEVANT_ENTITIES == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: cat entities.txt | entities-service upload --auto-confirm --strict --format=json -
         env:
           ENTITIES_SERVICE_ACCESS_TOKEN: ${{ secrets.ENTITIES_SERVICE_ACCESS_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ ci:
   autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
   autoupdate_schedule: 'weekly'
   submodules: false
+  skip: [validate-entities]
 
 # Hooks
 repos:

--- a/requirements_upload.txt
+++ b/requirements_upload.txt
@@ -1,1 +1,1 @@
-entities-service[cli] @ git+https://github.com/SINTEF/entities-service.git@v0.5.0
+entities-service[cli] @ git+https://github.com/SINTEF/entities-service.git@v0.7.2


### PR DESCRIPTION
## AI Summary

This pull request includes updates to the continuous deployment workflow and dependency version for the entities service. The most important changes include modifications to the GitHub Actions workflow to use `GITHUB_OUTPUT` instead of `GITHUB_ENV` and updating the version of the `entities-service` dependency.

Updates to GitHub Actions workflow:

* [`.github/workflows/cd_upload_entities.yml`](diffhunk://#diff-e885cd73748e9e3c3005cef4ecc61a842965a5e0a0f6952eb9d4170bfe10759bL45-R62): Changed the environment variable handling from `GITHUB_ENV` to `GITHUB_OUTPUT` for determining relevant entities.
* [`.github/workflows/cd_upload_entities.yml`](diffhunk://#diff-e885cd73748e9e3c3005cef4ecc61a842965a5e0a0f6952eb9d4170bfe10759bR35): Added an `id` to the "Gather Entities" step and updated conditional checks to use the outputs of this step.

Dependency version update:

* [`requirements_upload.txt`](diffhunk://#diff-659fb12bb03ba19679ade5304b805dd0d84358eae385bbd111e8ddcaf4cb1384L1-R1): Updated the `entities-service` dependency from version `v0.5.0` to `v0.7.2`.